### PR TITLE
Updated compiler pass to always use the config key in service IDs

### DIFF
--- a/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
@@ -35,7 +35,7 @@ class ServiceCreationCompilerPass implements CompilerPassInterface
                             $memcacheHost, $memcachePort
                         ));
                         $memcache->setPublic(false);
-                        $memcacheId = sprintf('liip_doctrine_cache.%s_memcache_instance', $namespace);
+                        $memcacheId = sprintf('liip_doctrine_cache.%s_memcache_instance', $name);
                         $container->setDefinition($memcacheId, $memcache);
                     } else {
                         $memcacheId = $config['id'];
@@ -52,7 +52,7 @@ class ServiceCreationCompilerPass implements CompilerPassInterface
                             $memcachedHost, $memcachedPort
                         ));
                         $memcached->setPublic(false);
-                        $memcachedId = sprintf('liip_doctrine_cache.%s_memcached_instance', $namespace);
+                        $memcachedId = sprintf('liip_doctrine_cache.%s_memcached_instance', $name);
                         $container->setDefinition($memcachedId, $memcached);
                     } else {
                         $memcachedId = $config['id'];


### PR DESCRIPTION
This allows for instance to set different namespaces depending on the environment; useful when using different environments on the same server.

i.e:

``` yaml
liip_doctrine_cache:
    namespaces:
        feed:
            namespace: "feed_%kernel.environment%"
            type: %cache.type%
            port: %cache.port%
            host: %cache.host%
```
