### PR TITLE
added support to memcache for UNIX domain sockets

### DIFF
--- a/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
@@ -29,7 +29,7 @@ class ServiceCreationCompilerPass implements CompilerPassInterface
                 case 'memcache':
                     if (empty($config['id'])) {
                         $memcacheHost = !empty($config['host']) ? $config['host'] : '%liip_doctrine_cache.memcache_host%';
-                        $memcachePort = !empty($config['port']) ? $config['port'] : '%liip_doctrine_cache.memcache_port%';
+                        $memcachePort = isset($config['port']) ? $config['port'] : '%liip_doctrine_cache.memcache_port%';
                         $memcache = new Definition('Memcache');
                         $memcache->addMethodCall('addServer', array(
                             $memcacheHost, $memcachePort


### PR DESCRIPTION
!empty evaluatues config param "port" with value "0" to false

see: http://www.php.net/manual/en/memcache.connect.php
"variable host: Point to the host where memcached is listening for connections. This parameter may also specify other transports like unix:///path/to/memcached.sock to use UNIX domain sockets, in this case port must also be set to 0."
