### PR TITLE
add ability to set timeout when instantiating memcache server

### DIFF
--- a/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceCreationCompilerPass.php
@@ -30,9 +30,10 @@ class ServiceCreationCompilerPass implements CompilerPassInterface
                     if (empty($config['id'])) {
                         $memcacheHost = !empty($config['host']) ? $config['host'] : '%liip_doctrine_cache.memcache_host%';
                         $memcachePort = isset($config['port']) ? $config['port'] : '%liip_doctrine_cache.memcache_port%';
+                        $memcacheTimeout = !empty($config['timeout']) ? $config['timeout'] : '%liip_doctrine_cache.memcache_timeout%';
                         $memcache = new Definition('Memcache');
                         $memcache->addMethodCall('addServer', array(
-                            $memcacheHost, $memcachePort
+                            $memcacheHost, $memcachePort, $memcacheTimeout
                         ));
                         $memcache->setPublic(false);
                         $memcacheId = sprintf('liip_doctrine_cache.%s_memcache_instance', $name);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('type')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('host')->defaultNull()->end()
                             ->scalarNode('port')->defaultNull()->end()
+                            ->scalarNode('timeout')->defaultNull()->end()
                             ->scalarNode('id')->defaultNull()->end()
                             ->scalarNode('directory')->defaultNull()->end()
                             ->scalarNode('extension')->defaultNull()->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,6 +12,7 @@
         <parameter key="liip_doctrine_cache.memcache.class">Doctrine\Common\Cache\MemcacheCache</parameter>
         <parameter key="liip_doctrine_cache.memcache_host">localhost</parameter>
         <parameter key="liip_doctrine_cache.memcache_port">11211</parameter>
+        <parameter key="liip_doctrine_cache.memcache_timeout">1</parameter>
         <parameter key="liip_doctrine_cache.memcached.class">Doctrine\Common\Cache\MemcachedCache</parameter>
         <parameter key="liip_doctrine_cache.memcached_host">localhost</parameter>
         <parameter key="liip_doctrine_cache.memcached_port">11211</parameter>


### PR DESCRIPTION
In our test environment we are confronted with timeout problems when using memcache server with default timeout of 1 second. Our continious builds are failing because of that.
So we want to increase the timeout of memcache server by configuration.
