### PR TITLE
Add a batch command allowing to invalidate a whole namespace

### DIFF
--- a/Command/CacheDeleteAllCommand.php
+++ b/Command/CacheDeleteAllCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Liip\DoctrineCacheBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\Common\Cache\CacheProvider;
+
+/**
+ * CacheDeleteAllCommand
+ * Allows to launch a delete all on the underlying cache provider
+ * the main difference with a flush is that only the given namespace 
+ * is affected by the delete command (especially useful when a single
+ * cache provider hosts multiple namespaces)
+ */
+class CacheDeleteAllCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('liip:doctrine-cache:delete-all');
+        $this->setDescription('Clean the given cache');
+        $this->addArgument(
+            'cache-name', InputArgument::REQUIRED, 'Which cache to clean?'
+        );
+        $this->addArgument(
+            'use-namespace',
+            InputArgument::OPTIONAL,
+            'Which namespace to use (defaults to the one specified in the container configuration)'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Retrieve the cache provider associated to the given cache-name
+        $cacheName = $input->getArgument('cache-name');
+        $serviceName = 'liip_doctrine_cache.ns.'.$cacheName;
+        $cacheProvider = $this->getContainer()->get($serviceName);
+
+        if ($cacheProvider instanceof CacheProvider) {
+            // In case we force another namespace, force it in the cache provider
+            $namespace = $input->getArgument('use-namespace');
+            if ('' != $namespace) {
+                $cacheProvider->setNamespace($namespace);
+            } else {
+                $namespace = $cacheProvider->getNamespace();
+            }
+
+            // Do the actual cache invalidation for the given namespace
+            $cacheProvider->deleteAll();
+        } else {
+            // Should not happen...
+            throw new \RuntimeException(sprintf(
+                'Unable to get a cache named %s from the container',
+                $cacheName
+            ));
+        }
+
+        $output->writeln(sprintf(
+            'The namespace %s of cache %s has been fully invalidated',
+            $namespace,
+            $cacheName
+        ));
+    }
+}


### PR DESCRIPTION
When a cache system (say Memcached farm) is used to store multiple namespaces, rather than flushing the whole cache, it can be relevant to invalidate only one namespace.

This is the purpose of the deleteAll method implemented by all cache providers in Doctrine Cache (see Doctrine\Common\Cache\CacheProvider abstract class).

Of course, this is only useful when the cache storage is reachable by both a CLI command and the PHP SAPI used to treat pages/webservices. This excludes APC for instance which stores its data in a shared memory available only in the same context.
But this can be really interesting for shared cache storage like memcache or Couchbase.
